### PR TITLE
Use NavigationSplitView

### DIFF
--- a/DeletionTest/ContentView.swift
+++ b/DeletionTest/ContentView.swift
@@ -17,30 +17,33 @@ struct ContentView: View {
   private var items: FetchedResults<Item>
 
   var body: some View {
-    NavigationStack {
-      List {
-        ForEach(items) { item in
-          NavigationLink {
-            DetailView(item: item)
-          } label: {
-            // A preview of the item
-            Text(item.timestamp!, formatter: itemFormatter)
+    NavigationSplitView(
+      sidebar: {
+        List {
+          ForEach(items) { item in
+            NavigationLink {
+              DetailView(item: item)
+            } label: {
+              // A preview of the item
+              Text(item.timestamp!, formatter: itemFormatter)
+            }
           }
+          .onDelete(perform: deleteItems)
         }
-        .onDelete(perform: deleteItems)
-      }
-      .toolbar {
-        ToolbarItem(placement: .navigationBarTrailing) {
-          EditButton()
-        }
-        ToolbarItem {
-          Button(action: addItem) {
+        .toolbar {
+          ToolbarItem(placement: .navigationBarTrailing) {
+            EditButton()
+          }
+          ToolbarItem {
+            Button(action: addItem) {
               Label("Add Item", systemImage: "plus")
+            }
           }
         }
+      }, detail: {
+        Text("Select an item")
       }
-      Text("Select an item")
-    }
+    )
   }
 
   private func addItem() {


### PR DESCRIPTION
Looks like you got this working by deferring the save. I just looked at my inventory app and I do that (even for soft-deletes) 🤦 Totally forgot about that.

Here's an experiment using `NavigationSplitView` which restores behavior similar to `NavigationView`.

iPad
===
![Simulator Screenshot - iPad Air (5th generation) - 2023-12-24 at 21 00 10](https://github.com/mgadda/DeletionTest/assets/103135/4f101e65-2488-4c35-9e6e-8a095185cc96)

macOS
===
<img width="1028" alt="Screenshot 2023-12-24 at 8 59 04 PM" src="https://github.com/mgadda/DeletionTest/assets/103135/22409b66-d689-4a61-96b8-8ed98e5220cc">
